### PR TITLE
Linesandmath

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -27,7 +27,7 @@ body{
 	cursor: pointer;
 }
 .control{
-	margin-top:20px;
+	margin-bottom:10px;
 }
 .control-orb{
 	border-radius: 100%;
@@ -40,6 +40,13 @@ body{
 }
 .control-orb:hover{
 	background: lightgreen;
+}
+.control-label{
+	color: white;
+	font-family: monospace;
+	text-align: left;
+	margin: 5px 0 5px 10px;
+	text-decoration: underline;
 }
 #grid-coordinates{
 	position: absolute;
@@ -119,4 +126,8 @@ svg {
 }
 .cursorBlock{
 	fill:grey;
+}
+#path-text{
+	color: white;
+	font-family: monospace;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -84,30 +84,23 @@ svg {
 }
 .grid-line{
 	/*fill: transparent;*/
-	stroke: rgba(238,238,238, 0.8);
+	stroke: rgb(238,238,238);
 	stroke-width: 0.2;
-}
-.grid-square:hover{
-	fill: rgba(20, 20, 20, 0.8);
 }
 #svg-background{
 	fill:white;
 }
 .type0{
 	fill:salmon;
-	fill-opacity: 0.5;
 }
 .type1{
 	fill:lightblue;
-	fill-opacity: 0.5;
 }
 .type2{
 	fill:lightgreen;
-	fill-opacity: 0.5;
 }
 .type3{
 	fill:white;
-	fill-opacity: 0.5;
 }
 #type0-brush{
 	background:salmon;

--- a/css/styles.css
+++ b/css/styles.css
@@ -124,3 +124,6 @@ svg {
 .brush:hover{
 	border: 2px solid white;
 }
+.cursorBlock{
+	fill:salmon;
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -60,7 +60,7 @@ body{
 #map-container{
 	width:100%;
 	max-height:100vh;
-	box-sizing: content-box;
+	/*box-sizing: content-box;*/
 }
 svg {
 	-webkit-backface-visibility: initial !important;
@@ -85,7 +85,7 @@ svg {
 .grid-line{
 	/*fill: transparent;*/
 	stroke: rgba(238,238,238, 0.8);
-	stroke-width: 0.6;
+	stroke-width: 0.2;
 }
 .grid-square:hover{
 	fill: rgba(20, 20, 20, 0.8);

--- a/css/styles.css
+++ b/css/styles.css
@@ -85,7 +85,7 @@ svg {
 .grid-line{
 	/*fill: transparent;*/
 	stroke: rgba(238,238,238, 0.8);
-	stroke-width: 0.2;
+	stroke-width: 0.6;
 }
 .grid-square:hover{
 	fill: rgba(20, 20, 20, 0.8);

--- a/css/styles.css
+++ b/css/styles.css
@@ -82,10 +82,10 @@ svg {
 .park{
 	fill:lightgreen;
 }
-.grid-square{
-	fill: transparent;
+.grid-line{
+	/*fill: transparent;*/
 	stroke: rgba(238,238,238, 0.8);
-	stroke-width: 0.4;
+	stroke-width: 0.2;
 }
 .grid-square:hover{
 	fill: rgba(20, 20, 20, 0.8);

--- a/css/styles.css
+++ b/css/styles.css
@@ -118,5 +118,5 @@ svg {
 	border: 2px solid white;
 }
 .cursorBlock{
-	fill:salmon;
+	fill:grey;
 }

--- a/index.html
+++ b/index.html
@@ -9,21 +9,27 @@
 
 		<div id="control-panel">
 			<div id="control-handle"></div>
+			<div class=" control-label">Grid Width</div>
 			<input type="number" id="grid-dimension-picker" class="control" max="200" min="10" value="20">
+			<div class=" control-label">Grid</div>
 			<div class="orb-row">
 				<button id="create-grid-button" class="control control-orb">C</button>
 				<button id="remove-grid-button" class="control control-orb">R</button>
 				<button id="hide-grid-button" class="control control-orb">H</button>
 				<button id="show-grid-button" class="control control-orb">S</button>
 			</div>
-			Controls
+			<div class=" control-label">Coloring</div>
 			<div class="orb-row">
 				<button id="type0-brush" class="control control-orb brush"></button>
 				<button id="type1-brush" class="control control-orb brush"></button>
 				<button id="type2-brush" class="control control-orb brush"></button>
 				<button id="type3-brush" class="control control-orb brush"></button>
 			</div>
-			Coloring
+			<div class=" control-label">Path Finding</div>
+			<div>
+				<button id="path-start" class="control">Start</button>
+				<div id="path-text">Lets find some paths!</div>
+			</div>
 			<div id="grid-coordinates">
 				<span id="coordX" class="coord">
 					x:<span id="square-coordX"></span>

--- a/js/main.js
+++ b/js/main.js
@@ -243,7 +243,8 @@ function createMap(mapdata){
 	function findCoordinates(event){
 		if(map.mapArray.length>0){
 			var gridWidth = map.mapArray[0].length;
-			var gridHeight = map.mapArray.length;
+			var gridHeight = map.mapArray.length-1;
+			console.log('mapWidth: '+mapWidth+' gridWidth: '+gridWidth+' offsetX: '+event.offsetX);
 			var x = Math.floor(event.offsetX/(mapWidth/gridWidth));
 			var y = Math.floor(event.offsetY/(mapHeight/gridHeight));
 			if(map.cursorSquareCoord[0]!=x || map.cursorSquareCoord[1]!= y){

--- a/js/main.js
+++ b/js/main.js
@@ -149,7 +149,7 @@ function createMap(mapdata){
 				canvas.rect(pixels[0], pixels[1], (offsetX+1)*squareWidth, (offsetY+1)*squareWidth).attr({class:this.brush});
 			}
 			if(permanent){
-
+				
 			}
 		},
 		getTopLeftPixels: function(coordinates){

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-  
+
   //////////////////////////////////////
  ///// Initialize Snap.svg Object /////
 //////////////////////////////////////
@@ -34,6 +34,11 @@ function createMap(mapdata){
 		this.markCenter();
 		this.brush = 'type1';
 		this.cursorSquareCoord = [0, 0];
+		this.type0coords=[];
+		this.type1coords=[];
+		this.type2coords=[];
+		this.type3coords=[];
+
 	}
 
 	  //////////////////////////////////////
@@ -97,6 +102,12 @@ function createMap(mapdata){
 		},
 		eraseCursorBlock:function(){
 			this.tempSquares.clear();
+		},
+		colorSquares: function(squares){
+
+		},
+		colorArray: function(coordinates){
+
 		}
 	}
 
@@ -115,10 +126,10 @@ function createMap(mapdata){
 	var $themap = $mapContainer.find('svg');
 	var $controlHandle = $('#control-handle');
 	var $controlPanel = $('#control-panel');
-	var $coordX = $('#square-coordX')
-	var $coordY = $('#square-coordY')
-	var mapWidth = $themap.width();
-	var mapHeight = $themap.height();
+	var $coordX = $('#square-coordX');
+	var $coordY = $('#square-coordY');
+	var mapWidth = window.innerWidth;
+	var mapHeight = window.innerHeight;
 
 	  //////////////////////////////////////
 	 //////////// Panzoom.js //////////////
@@ -155,8 +166,8 @@ function createMap(mapdata){
 	//Reset dimensions on resize for panzoom.
 	$(window).on('resize', function() {
 	  	$themap.panzoom('resetDimensions');
-	 	mapWidth = $themap.width();
-		mapHeight = $themap.height();
+		mapWidth = window.innerWidth;
+		mapHeight = window.innerHeight;
 	});
 
 	//Ensures the control handle remains green on drag.
@@ -171,7 +182,7 @@ function createMap(mapdata){
 	 /////////// Control Panel ////////////
 	//////////////////////////////////////
 
-	// Buttons
+	// Grid Creation
 
 		$controlPanel.on('click', '#create-grid-button', createGrid)
 					 .on('click', '#remove-grid-button', removeGrid)
@@ -190,30 +201,14 @@ function createMap(mapdata){
 		}
 
 		function hideGrid(){
-			map.$gridSquares.hide();
+			map.$gridLines.hide();
 		}
 
 		function showGrid(){
-			map.$gridSquares.show();
+			map.$gridLines.show();
 		}
 
-	// Coordinates
-
-		$themap.on('mouseover', '.grid-square', readCoords);
-		$themap.on('mouseout', '.grid-square', emptyCoords);
-
-		function emptyCoords(){
-			$coordX.text(' ');
-			$coordY.text(' ');
-		}
-
-		function readCoords(){
-			var coords =  $(this).attr('id').slice(6).split('-');
-			$coordX.text(parseInt(coords[0])+1);
-			$coordY.text(parseInt(coords[1])+1);
-		}
-
-	// Grid Coloring
+	// Brush Selection
 
 		$controlPanel.on('click', '#type0-brush', chooseBrush)
 					 .on('click', '#type1-brush', chooseBrush)
@@ -238,15 +233,16 @@ function createMap(mapdata){
 	  //////////////////////////////////////
 	 ////////// Grid Navigation ///////////
 	//////////////////////////////////////
-	$themap.on('mousemove', findCoordinates)
+	$themap.on('mousemove', findCoordinates);
 
 	function findCoordinates(event){
 		if(map.mapArray.length>0){
 			var gridWidth = map.mapArray[0].length;
-			var gridHeight = map.mapArray.length-1;
-			console.log('mapWidth: '+mapWidth+' gridWidth: '+gridWidth+' offsetX: '+event.offsetX);
-			var x = Math.floor(event.offsetX/(mapWidth/gridWidth));
-			var y = Math.floor(event.offsetY/(mapHeight/gridHeight));
+			var gridHeight = map.mapArray.length;
+			var squareSize = mapWidth/gridWidth;
+			var x = Math.floor((event.offsetX-1)/squareSize);
+			var y = Math.floor((event.offsetY-1)/squareSize);			
+
 			if(map.cursorSquareCoord[0]!=x || map.cursorSquareCoord[1]!= y){
 				map.eraseCursorBlock();
 				map.drawCursorBlock([x, y]);
@@ -256,103 +252,5 @@ function createMap(mapdata){
 		}
 	}
 		console.log(map.width);
-
-
-	  //////////////////////////////////////
-	 /////////// Grid Coloring ////////////
-	//////////////////////////////////////
-
-	var multiDrag = false;
-	var brushDrag = false;
-	var didPan = false;
-	var startingCoord;
-	var squaresList = [];
-
-	$themap.on('mousedown','.grid-square', chooseSquareDown);
-	$themap.on('mouseup','.grid-square', chooseSquareUp);
-
-	function chooseSquareDown(event){
-		startingCoord =  $(this).attr('id').slice(6).split('-');
-		squaresList.push(startingCoord);
-			// console.log(squaresList);
-		if(event.shiftKey || event.ctrlKey){
-			$themap.panzoom("disable");
-			$themap.on('mouseover','.grid-square', trackSquares);
-			if(event.shiftKey){
-				multiDrag = true;
-			}else if(event.ctrlKey){
-				brushDrag = true;
-			}
-		}
-	}
-
-	function trackSquares(event){
-		// console.log(squaresList);
-		var currentCoord = $(this).attr('id').slice(6).split('-');
-		if(multiDrag){
-			squaresList = [];
-			// console.log('startX: '+startingCoord[0]+'  startY: '+startingCoord[1]+'  currentX: '+currentCoord[0]+'  currentY: '+currentCoord[1]);
-			var offsetX = 0-(startingCoord[0]-currentCoord[0]);
-			var offsetY = startingCoord[1]-currentCoord[1];
-			// console.log('offsetX: '+offsetX+' offsetY: '+offsetY);
-			if(offsetX>=0 && offsetY>=0){
-				// console.log('quadI');
-				for(var i=0;i<=offsetX; i++){
-					for(var j=0;j>=offsetY*-1; j--){
-						squaresList.push([parseInt(startingCoord[0])+i,parseInt(startingCoord[1])+j]);
-					}
-				}
-			} else if(offsetX<=0 && offsetY>=0){
-				// console.log('quadII');
-				for(var i=0;i>=offsetX; i--){
-					for(var j=0;j>=offsetY*-1; j--){
-						squaresList.push([parseInt(startingCoord[0])+i,parseInt(startingCoord[1])+j]);
-					}
-				}
-			}  else if(offsetX<=0 && offsetY<=0){
-				// console.log('quadIII');
-				for(var i=0;i>=offsetX; i--){
-					for(var j=0;j<=offsetY*-1; j++){
-						squaresList.push([parseInt(startingCoord[0])+i,parseInt(startingCoord[1])+j]);
-					}
-				}
-			} else if(offsetX>=0 && offsetY<=0){
-				// console.log('quadIV');
-				for(var i=0;i<=offsetX; i++){
-					for(var j=0;j<=offsetY*-1; j++){
-						squaresList.push([parseInt(startingCoord[0])+i,parseInt(startingCoord[1])+j]);
-					}
-				}
-			} else{
-				console.log('uh oh');
-			}
-			map.colorSquares(squaresList);
-			// console.log(squaresList);
-		} else if(brushDrag){
-			squaresList.push(currentCoord);
-			map.colorSquares(squaresList);
-		}
-	}
-
-	function chooseSquareUp(event){
-		if(multiDrag || brushDrag){
-			$themap.panzoom("enable");
-			$themap.unbind('mouseover', trackSquares);
-			if(multiDrag){
-				multiDrag = false;
-				console.log('You just multiDragged');
-				map.colorArray(squaresList);
-			} else if(brushDrag){
-				brushDrag = false;
-				console.log('You just brushDragged');
-				map.colorSquares(squaresList);
-				map.colorArray(squaresList);
-			}
-		}  else if(!didPan){
-			map.colorSquares(squaresList);
-			map.colorArray(squaresList);
-		}
-		squaresList = [];
-	}
-
 }
+

--- a/js/main.js
+++ b/js/main.js
@@ -23,6 +23,8 @@ function createMap(mapdata){
 	var Mapster = function(map) {
 		this.g = map;
 		this.mapArray = [];
+		this.squares = this.g.group();
+		this.tempSquares = this.g.group();
 		this.gridSet = this.g.group();
 		this.$gridSquares = $('.grid-square');
 		this.$gridLines = $('.grid-line');
@@ -31,6 +33,7 @@ function createMap(mapdata){
 		this.height = this.bounding.height;
 		this.markCenter();
 		this.brush = 'type1';
+		this.cursorSquareCoord = [0, 0];
 	}
 
 	  //////////////////////////////////////
@@ -84,6 +87,16 @@ function createMap(mapdata){
 			var oldBrush = this.brush;
 			this.brush = newBrush;
 			return oldBrush;
+		},
+		drawCursorBlock: function(coordinates){
+			this.cursorSquareCoord = coordinates;
+			var squareWidth = this.width/this.mapArray[0].length;
+			var pixelX = coordinates[0]*squareWidth;
+			var pixelY = coordinates[1]*squareWidth;
+			this.tempSquares.rect(pixelX, pixelY, squareWidth, squareWidth).attr({class: "cursorBlock"})
+		},
+		eraseCursorBlock:function(){
+			this.tempSquares.clear();
 		}
 	}
 
@@ -104,6 +117,8 @@ function createMap(mapdata){
 	var $controlPanel = $('#control-panel');
 	var $coordX = $('#square-coordX')
 	var $coordY = $('#square-coordY')
+	var mapWidth = $themap.width();
+	var mapHeight = $themap.height();
 
 	  //////////////////////////////////////
 	 //////////// Panzoom.js //////////////
@@ -139,7 +154,9 @@ function createMap(mapdata){
 
 	//Reset dimensions on resize for panzoom.
 	$(window).on('resize', function() {
-	  $themap.panzoom('resetDimensions');
+	  	$themap.panzoom('resetDimensions');
+	 	mapWidth = $themap.width();
+		mapHeight = $themap.height();
 	});
 
 	//Ensures the control handle remains green on drag.
@@ -221,21 +238,20 @@ function createMap(mapdata){
 	  //////////////////////////////////////
 	 ////////// Grid Navigation ///////////
 	//////////////////////////////////////
-	var mapWidth = $themap.width();
-	var mapHeight = $themap.height();
 	$themap.on('mousemove', findCoordinates)
 
 	function findCoordinates(event){
 		if(map.mapArray.length>0){
-			var matrix = $themap.panzoom('getMatrix');
 			var gridWidth = map.mapArray[0].length;
 			var gridHeight = map.mapArray.length;
-			var offsetX = (event.offsetX/matrix[0])+matrix[4];
-			var offsetY = (event.offsetY/matrix[0])+matrix[5];
-			var x = Math.floor(offsetX/(mapWidth/gridWidth));
-			var y = Math.floor(offsetY/(mapHeight/gridHeight));
-			$coordX.text(x);
-			$coordY.text(y);
+			var x = Math.floor(event.offsetX/(mapWidth/gridWidth));
+			var y = Math.floor(event.offsetY/(mapHeight/gridHeight));
+			if(map.cursorSquareCoord[0]!=x || map.cursorSquareCoord[1]!= y){
+				map.eraseCursorBlock();
+				map.drawCursorBlock([x, y]);
+				$coordX.text(x);
+				$coordY.text(y);
+			}
 		}
 	}
 		console.log(map.width);

--- a/js/main.js
+++ b/js/main.js
@@ -25,6 +25,7 @@ function createMap(mapdata){
 		this.mapArray = [];
 		this.gridSet = this.g.group();
 		this.$gridSquares = $('.grid-square');
+		this.$gridLines = $('.grid-line');
 		this.bounding = this.g.getBBox();
 		this.width = this.bounding.width;
 		this.height = this.bounding.height;
@@ -60,17 +61,21 @@ function createMap(mapdata){
 		drawGrid: function(){
 			this.removeGrid();
 			var squareWidth = this.width/this.mapArray[0].length;
+			var height = this.height;
+			var width = this.width;
 			var x=0;
 			var y=0;
-			for(var i=0; i<this.mapArray.length; i++){
-				x=0;
-				for(var j=0; j<this.mapArray[i].length; j++){
-					this.gridSet.rect(x, y, squareWidth, squareWidth).attr({class:"grid-square type"+this.mapArray[i][j], id:"square"+j+'-'+i});
-					x+=squareWidth;
-				}
-				y+=squareWidth;
+			//vertical lines
+			for(var i=0; i<=this.mapArray[0].length; i++){
+				x = squareWidth*i;
+				this.gridSet.line(x, 0, x, height ).attr({class: 'grid-line'});
 			}
-			this.$gridSquares = $('.grid-square');
+			//horizontal lines
+			for(var i=0; i<=this.mapArray.length; i++){
+				y = squareWidth*i;
+				this.gridSet.line(0, y, width, y).attr({class: 'grid-line'});
+			}
+			this.$gridLines = $('.grid-line');
 		},
 		removeGrid: function(){
 			this.gridSet.clear();
@@ -79,21 +84,6 @@ function createMap(mapdata){
 			var oldBrush = this.brush;
 			this.brush = newBrush;
 			return oldBrush;
-		},
-		colorSquares: function(squares){
-			for(var i=0; i< squares.length; i++){
-				var coords = squares[i];
-				var squareQuery = 'svg #square'+coords[0]+'-'+coords[1];
-				var previousType = $(squareQuery).attr('class').split(' ')[1];
-				this.g.select(squareQuery).removeClass(previousType);
-				this.g.select(squareQuery).addClass(this.brush);
-			}
-		}, 
-		colorArray: function(squares){
-			for(var i=0; i< squares.length; i++){
-				var coords = squares[i];
-				this.mapArray[coords[1]][coords[0]] = this.brush.slice(4);
-			}
 		}
 	}
 
@@ -226,6 +216,19 @@ function createMap(mapdata){
 			$('#'+oldBrush+'-brush').css('border', '');
 			$('#'+brush+'-brush').css('border', '2px solid white');
 		}
+
+
+	  //////////////////////////////////////
+	 ////////// Grid Navigation ///////////
+	//////////////////////////////////////
+
+	// $themap.on('mousemove', findCoordinates)
+
+	// function findCoordinates(event){
+	// 	var gridWidth = this.mapArray[0].length;
+	// 	var gridHeight = this.mapArray.length;
+		
+	// }
 
 
 	  //////////////////////////////////////

--- a/js/main.js
+++ b/js/main.js
@@ -401,7 +401,12 @@ function createMap(mapdata){
 	 /////////// Path Finding /////////////
 	//////////////////////////////////////
 
-	
+	$controlPanel.on('click', '#path-start', beginPathfinding);
+
+	function beginPathfinding(){
+		
+	}
+
 
 
 	  //////////////////////////////////////

--- a/js/main.js
+++ b/js/main.js
@@ -337,53 +337,76 @@ function createMap(mapdata){
 	$themap.on('mouseup', mapMouseup);
 
 	function mapMousedown(event){
-		if(actOnGrid()){
-			event.preventDefault();
-			blocksInProgress = [];
-			blocksInProgress.push(map.currentCoord);
-			if(event.shiftKey || event.ctrlKey){
-				$themap.panzoom('option', 'disablePan', true);
-				$themap.panzoom('option', 'disableZoom', true);
-				if(event.shiftKey){
-					multiDrag = true;
-					$themap.on('mousemove', multiDragging);
-				}
-				else if(event.ctrlKey){
-					brushDrag = true;
-					map.colorSquares(blocksInProgress[0]);
-					$themap.on('mousemove', brushDragging);
-				}
+		if(!actOnGrid()) return false;
+		didPan = false;
+		event.preventDefault();
+		blocksInProgress = [];
+		blocksInProgress.push(map.currentCoord);
+		if(event.shiftKey || event.ctrlKey){
+			$themap.panzoom('option', 'disablePan', true);
+			$themap.panzoom('option', 'disableZoom', true);
+			if(event.shiftKey){
+				multiDrag = true;
+				$themap.on('mousemove', multiDragging);
 			}
+			else if(event.ctrlKey){
+				brushDrag = true;
+				map.colorSquares(blocksInProgress[0]);
+				$themap.on('mousemove', brushDragging);
+			}
+		}
+		else{
+			$themap.on('mousemove', isPanning);
 		}
 	}
 
 	function mapMouseup(event){
-		if(actOnGrid() && !didPan){
-			$themap.panzoom('option', 'disablePan', false);
-			$themap.panzoom('option', 'disableZoom', false);
-			if(multiDrag){
-				$themap.unbind('mousemove', multiDragging);
-				map.multiDrag(blocksInProgress[0], map.currentCoord);
-				multiDrag = false;
+		if(actOnGrid()){
+			if(multiDrag||brushDrag){
+				$themap.panzoom('option', 'disablePan', false);
+				$themap.panzoom('option', 'disableZoom', false);
+				if(multiDrag){
+					$themap.unbind('mousemove', multiDragging);
+					map.multiDrag(blocksInProgress[0], map.currentCoord);
+					multiDrag = false;
+				}
+				else if(brushDrag){
+					$themap.unbind('mousemove', brushDragging);
+					map.colorArray(blocksInProgress);
+					brushDrag = false;
+				}
 			}
-			else if(brushDrag){
-				$themap.unbind('mousemove', brushDragging);
+			else if(!didPan){
+				$themap.unbind('mousemove', isPanning);
+				map.colorSquares(blocksInProgress[0]);
 				map.colorArray(blocksInProgress);
-				brushDrag = false;
-			}
-			else{
-
 			}
 		}
 	}
+	function isPanning(){
+		didPan = true;
+	}
 	function brushDragging(){
-		if(arraysMatch(map.currentCoord, blocksInProgress[blocksInProgress.length-1])) return false;
+		if(arraysMatch(map.currentCoord, blocksInProgress[blocksInProgress.length-1]) || arrayContains(blocksInProgress, map.currentCoord)) return true;
+
 		blocksInProgress.push(map.currentCoord);
 		map.colorSquares(blocksInProgress[blocksInProgress.length-1]);
 	}
 	function multiDragging(){
 		map.multiDragDisplay(blocksInProgress[0]);
 	}
+
+
+	  //////////////////////////////////////
+	 /////////// Path Finding /////////////
+	//////////////////////////////////////
+
+	
+
+
+	  //////////////////////////////////////
+	 ///////// Utility Functions //////////
+	//////////////////////////////////////
 
 	function arraysMatch(a, b){
 		if(a === b) return true;
@@ -393,6 +416,13 @@ function createMap(mapdata){
 			if(a[i] != b[i]) return false;
 		}
 		return true;
+	}
+
+	function arrayContains(a, b){
+		for(var i=0; i<a.length; i++){
+			if(arraysMatch(a[i], b)) return true;
+		}
+		return false;
 	}
 
 

--- a/js/main.js
+++ b/js/main.js
@@ -221,14 +221,24 @@ function createMap(mapdata){
 	  //////////////////////////////////////
 	 ////////// Grid Navigation ///////////
 	//////////////////////////////////////
+	var mapWidth = $themap.width();
+	var mapHeight = $themap.height();
+	$themap.on('mousemove', findCoordinates)
 
-	// $themap.on('mousemove', findCoordinates)
-
-	// function findCoordinates(event){
-	// 	var gridWidth = this.mapArray[0].length;
-	// 	var gridHeight = this.mapArray.length;
-		
-	// }
+	function findCoordinates(event){
+		if(map.mapArray.length>0){
+			var matrix = $themap.panzoom('getMatrix');
+			var gridWidth = map.mapArray[0].length;
+			var gridHeight = map.mapArray.length;
+			var offsetX = (event.offsetX/matrix[0])+matrix[4];
+			var offsetY = (event.offsetY/matrix[0])+matrix[5];
+			var x = Math.floor(offsetX/(mapWidth/gridWidth));
+			var y = Math.floor(offsetY/(mapHeight/gridHeight));
+			$coordX.text(x);
+			$coordY.text(y);
+		}
+	}
+		console.log(map.width);
 
 
 	  //////////////////////////////////////


### PR DESCRIPTION
Instead of creating an individual SVG square for every element of the 2D array to aid in manipulation, the program now only creates the grid lines and simulates individual square selection by reading mouse position and using simple division. This allows for manipulation of 2d arrays of over 1 million elements, impossible in the previous version. 
Max Grid Width:
   previous version: 200 and took about 10 seconds to generate squares. (40,000 elements)
   current version: >1000 and takes milliseconds to load. (1 million elements)
